### PR TITLE
feat : 회원 관리 기능 추가, 리뷰 평균 별점 확인

### DIFF
--- a/src/main/java/com/zb/cinema/config/SecurityConfiguration.java
+++ b/src/main/java/com/zb/cinema/config/SecurityConfiguration.java
@@ -39,7 +39,7 @@ public class SecurityConfiguration {
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
 			.authorizeRequests()
 			.antMatchers("/", "/member/signup", "/member/login", "/notice/list/**",
-				"/notice/detail/**").permitAll()
+				"/notice/detail/**","/notice/info/**").permitAll()
 			//JwtFilter 추가
 			.and()
 			.addFilterBefore(this.authenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/zb/cinema/member/exception/MemberError.java
+++ b/src/main/java/com/zb/cinema/member/exception/MemberError.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum MemberError {
 
 	MEMBER_ALREADY_EMAIL("이미 등록된 e-mail 입니다."), MEMBER_NOT_FOUND(
-		"존재 하지 않는 ID 입니다."), MEMBER_PASSWORD_NOT_SAME("등록된 비밀 번호가 다릅니다.");
+		"존재 하지 않는 ID 입니다."), MEMBER_PASSWORD_NOT_SAME(
+		"등록된 비밀 번호가 다릅니다."), MEMBER_ROLE_UN_ACCESSIBLE("정지 회원입니다.");
 
 	private final String description;
 }

--- a/src/main/java/com/zb/cinema/member/service/MemberService.java
+++ b/src/main/java/com/zb/cinema/member/service/MemberService.java
@@ -69,6 +69,11 @@ public class MemberService implements UserDetailsService {
 		if (!passwordEncoder.matches(parameter.getPassword(), member.getPassword())) {
 			throw new MemberException(MemberError.MEMBER_PASSWORD_NOT_SAME);
 		}
+
+		if(MemberType.ROLE_UN_ACCESSIBLE.equals(member.getType())) {
+			throw new MemberException(MemberError.MEMBER_ROLE_UN_ACCESSIBLE);
+		}
+
 		return member;
 	}
 }

--- a/src/main/java/com/zb/cinema/movie/repository/MovieRepository.java
+++ b/src/main/java/com/zb/cinema/movie/repository/MovieRepository.java
@@ -3,6 +3,8 @@ package com.zb.cinema.movie.repository;
 import com.zb.cinema.movie.entity.Movie;
 import com.zb.cinema.movie.type.MovieStatus;
 import java.util.List;
+import java.util.Optional;
+import org.aspectj.apache.bcel.classfile.Module.Open;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +20,6 @@ public interface MovieRepository extends JpaRepository<Movie, Long> {
     List<Movie> findAllByActorsContaining(String actor);
 
     List<Movie> findAllByStatus(MovieStatus status);
+
+    Optional<Movie> findByCode(Long movieCode);
 }

--- a/src/main/java/com/zb/cinema/notice/controller/NoticeController.java
+++ b/src/main/java/com/zb/cinema/notice/controller/NoticeController.java
@@ -1,8 +1,8 @@
 package com.zb.cinema.notice.controller;
 
-import com.zb.cinema.config.jwt.TokenProvider;
 import com.zb.cinema.notice.model.DeleteReview;
 import com.zb.cinema.notice.model.ModifyReview;
+import com.zb.cinema.notice.model.ViewMovieInfo;
 import com.zb.cinema.notice.model.ReviewAllList;
 import com.zb.cinema.notice.model.ReviewByMovie;
 import com.zb.cinema.notice.model.ReviewDetail;
@@ -60,15 +60,24 @@ public class NoticeController {
 	}
 
 	/*
+		영화 정보, 별점 평균 정보 보기
+	 */
+	@GetMapping("/info/{movieCode}")
+	public ViewMovieInfo getMovieByInfo(@PathVariable Long movieCode) {
+		return noticeService.getMovieByInfo(movieCode);
+	}
+
+	/*
 	 	영화 별 후기 리스트 보기
 	 */
-	@GetMapping("/list/{movieCode}")
+	@GetMapping("/info/list/{movieCode}")
 	public List<ReviewByMovie> getReviewByMovie(@PathVariable Long movieCode) {
 
 		return noticeService.getReviewByMovie(movieCode).stream().map(
-			noticeDto -> ReviewByMovie.builder().email(noticeDto.getEmail())
-				.movieTitle(noticeDto.getMovieTitle()).contents(noticeDto.getContents())
-				.regDt(noticeDto.getRegDt()).build()).collect(Collectors.toList());
+				noticeDto -> ReviewByMovie.builder().email(noticeDto.getEmail())
+					.movieTitle(noticeDto.getMovieTitle()).contents(noticeDto.getContents())
+					.starRating(noticeDto.getStarRating()).regDt(noticeDto.getRegDt()).build())
+			.collect(Collectors.toList());
 	}
 
 	@PutMapping("/detail/{noticeId}")

--- a/src/main/java/com/zb/cinema/notice/model/ReviewByMovie.java
+++ b/src/main/java/com/zb/cinema/notice/model/ReviewByMovie.java
@@ -17,12 +17,14 @@ public class ReviewByMovie {
 	private String movieTitle;
 	private String email;
 	private String contents;
+	private int starRating;
 	private LocalDateTime regDt;
 
 	public static ReviewByMovie from(NoticeDto noticeDto) {
 
 		return ReviewByMovie.builder().movieTitle(noticeDto.getMovieTitle())
 			.email(noticeDto.getEmail()).contents(noticeDto.getContents())
+			.starRating(noticeDto.getStarRating())
 			.regDt(noticeDto.getRegDt()).build();
 	}
 

--- a/src/main/java/com/zb/cinema/notice/model/ViewMovieInfo.java
+++ b/src/main/java/com/zb/cinema/notice/model/ViewMovieInfo.java
@@ -1,0 +1,23 @@
+package com.zb.cinema.notice.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ViewMovieInfo {
+
+	private String movieTitle;
+	private String actors;
+	private String directors;
+	private String genre;
+	private String nation;
+	private double ratingAvg;
+
+}

--- a/src/main/java/com/zb/cinema/notice/respository/NoticeRepository.java
+++ b/src/main/java/com/zb/cinema/notice/respository/NoticeRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 
@@ -20,6 +21,11 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 	Optional<Notice> findById(Long noticeId);
 
 	Page<Notice> findByNoticeMovieCode(Long noticeMovie, Pageable pageable);
+
+	@Query("select avg(m.starRating)from Notice m "
+		+ "left outer join MovieCode mc on m.noticeMovie.code = mc.code "
+		+ "where mc.code in (:movieCode) group by mc.code")
+	Double findByNoticeMovieCode(Long movieCode);
 
 	void deleteAllById(Long noticeId);
 }

--- a/src/main/java/com/zb/cinema/notice/service/NoticeService.java
+++ b/src/main/java/com/zb/cinema/notice/service/NoticeService.java
@@ -7,13 +7,16 @@ import com.zb.cinema.member.entity.Member;
 import com.zb.cinema.member.exception.MemberError;
 import com.zb.cinema.member.exception.MemberException;
 import com.zb.cinema.member.repository.MemberRepository;
+import com.zb.cinema.movie.entity.Movie;
 import com.zb.cinema.movie.entity.MovieCode;
 import com.zb.cinema.movie.repository.MovieCodeRepository;
+import com.zb.cinema.movie.repository.MovieRepository;
 import com.zb.cinema.notice.entity.Notice;
 import com.zb.cinema.notice.exception.NoticeError;
 import com.zb.cinema.notice.exception.NoticeException;
 import com.zb.cinema.notice.model.DeleteReview;
 import com.zb.cinema.notice.model.ModifyReview;
+import com.zb.cinema.notice.model.ViewMovieInfo;
 import com.zb.cinema.notice.model.NoticeDto;
 import com.zb.cinema.notice.model.WriteReview;
 import com.zb.cinema.notice.respository.NoticeRepository;
@@ -40,6 +43,7 @@ public class NoticeService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final MovieCodeRepository movieCodeRepository;
+	private final MovieRepository movieRepository;
 	private final TokenProvider tokenProvider;
 
 	/*
@@ -93,6 +97,23 @@ public class NoticeService {
 		}
 	}
 
+	public ViewMovieInfo getMovieByInfo(Long movieCode) {
+
+		Optional<Movie> movieOptional = movieRepository.findByCode(movieCode);
+		Movie movie = movieOptional.get();
+
+		Double starAvg = noticeRepository.findByNoticeMovieCode(movieCode);
+
+		return ViewMovieInfo.builder()
+			.movieTitle(movie.getTitle())
+			.actors(movie.getActors())
+			.directors(movie.getDirectors())
+			.genre(movie.getGenre())
+			.nation(movie.getNation())
+			.ratingAvg(starAvg)
+			.build();
+	}
+
 	/*
 	 	영화 별 후기 리스트 보기
 	 */
@@ -104,7 +125,6 @@ public class NoticeService {
 		if (notice.isEmpty()) {
 			throw new NoticeException(NoticeError.MOVIE_REVIEW_NOT_FOUND);
 		}
-
 		return notice.stream().map(NoticeDto::fromEntity).collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
#### 작업 일자
23.01.19 ~ 23.01.20

### 구현 사항
- [x] 정지 회원 로그인 제한
- [x] 영화 별 리뷰 평균 별점 확인 (+영화 정보 확인)
- [x] 코드 수정

### 설명 및 내용
정지 처리된 회원은 로그인 할 수 없다.
영화 별 기본 정보, 리뷰 평균 별점 확인이 가능하다. 

### 질문
